### PR TITLE
Enable camelCase mapping for MyBatis

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -10,3 +10,5 @@ spring:
 mybatis:
   mapper-locations: classpath:mapper/*.xml
   type-aliases-package: com.library.entity
+  configuration:
+    map-underscore-to-camel-case: true

--- a/server/src/test/java/com/library/mapper/MapperMappingTest.java
+++ b/server/src/test/java/com/library/mapper/MapperMappingTest.java
@@ -1,0 +1,80 @@
+package com.library.mapper;
+
+import com.library.entity.Book;
+import com.library.entity.BookCopy;
+import com.library.entity.BorrowRecord;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MYSQL",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password="
+})
+@Transactional
+class MapperMappingTest {
+    @Autowired
+    private BookMapper bookMapper;
+    @Autowired
+    private BookCopyMapper bookCopyMapper;
+    @Autowired
+    private BorrowRecordMapper borrowRecordMapper;
+
+    @Test
+    void bookCopyMapping() {
+        Book book = new Book();
+        book.setTitle("t");
+        book.setAuthor("a");
+        book.setCategory("c");
+        book.setLocation("l");
+        bookMapper.insert(book);
+
+        BookCopy copy = new BookCopy();
+        copy.setBookId(book.getId());
+        copy.setCode("CODE1");
+        copy.setLocation("loc");
+        bookCopyMapper.insert(copy);
+
+        BookCopy loaded = bookCopyMapper.findById(copy.getId());
+        assertNotNull(loaded);
+        assertEquals(copy.getBookId(), loaded.getBookId());
+        assertEquals(copy.getCode(), loaded.getCode());
+    }
+
+    @Test
+    void borrowRecordMapping() {
+        Book book = new Book();
+        book.setTitle("t2");
+        book.setAuthor("a2");
+        book.setCategory("c2");
+        book.setLocation("l2");
+        bookMapper.insert(book);
+        BookCopy copy = new BookCopy();
+        copy.setBookId(book.getId());
+        copy.setCode("CODE2");
+        copy.setLocation("loc2");
+        bookCopyMapper.insert(copy);
+
+        BorrowRecord record = new BorrowRecord();
+        record.setCopyId(copy.getId());
+        record.setBorrower("someone");
+        record.setBorrowDate(LocalDate.now());
+        record.setReturnDate(null);
+        borrowRecordMapper.insert(record);
+
+        List<BorrowRecord> list = borrowRecordMapper.currentBorrows();
+        assertFalse(list.isEmpty());
+        BorrowRecord loaded = list.get(0);
+        assertEquals(record.getCopyId(), loaded.getCopyId());
+        assertNotNull(loaded.getBorrowDate());
+        assertNull(loaded.getReturnDate());
+    }
+}

--- a/server/src/test/resources/schema.sql
+++ b/server/src/test/resources/schema.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS book (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    title VARCHAR(255),
+    author VARCHAR(255),
+    category VARCHAR(255),
+    location VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS book_copy (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    book_id BIGINT,
+    code VARCHAR(255) UNIQUE,
+    location VARCHAR(255),
+    FOREIGN KEY(book_id) REFERENCES book(id)
+);
+
+CREATE TABLE IF NOT EXISTS borrow_record (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    copy_id BIGINT,
+    borrower VARCHAR(255),
+    borrow_date DATE,
+    return_date DATE,
+    FOREIGN KEY(copy_id) REFERENCES book_copy(id)
+);


### PR DESCRIPTION
## Summary
- configure MyBatis to convert snake_case columns
- add H2 as test dependency
- verify mapper results via new integration tests

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_68442f95d0788321a937da2f109076ad